### PR TITLE
Update README.md install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ output being generated.
 
 To install the library and command line program, use the following:
 
-	go get -u github.com/jteeuwen/go-bindata/...
+	go get -u github.com/a-urth/go-bindata/...
 
 
 ### Usage


### PR DESCRIPTION
Regardless of what happens in the long term, leaving the instructions as jteeuwen is misleading and potentially harmful.